### PR TITLE
Fix for custom node creation 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rete-stage0-render-plugin",
-  "version": "0.2.11",
+  "version": "0.2.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,6 @@ extend(RootControlComponent, BaseComponent);
 
 function createNode({ el, nodeProps, component }) {
   const comp = component.component ? new component.component(nodeProps) : new NodeComponent(nodeProps);
-  console.log(comp);
   nodeProps.node.stage0Context = comp;
   el.appendChild(comp.root);
   return comp;

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,8 @@ RootControlComponent.prototype.rootUpdate = function(_control) {
 extend(RootControlComponent, BaseComponent);
 
 function createNode({ el, nodeProps, component }) {
-  const comp = Object.create(component.component.prototype, nodeProps) || new NodeComponent(nodeProps);
+  const comp = component.component ? new component.component(nodeProps) : new NodeComponent(nodeProps);
+  console.log(comp);
   nodeProps.node.stage0Context = comp;
   el.appendChild(comp.root);
   return comp;

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ RootControlComponent.prototype.rootUpdate = function(_control) {
 extend(RootControlComponent, BaseComponent);
 
 function createNode({ el, nodeProps, component }) {
-  const comp = component.component || new NodeComponent(nodeProps);
+  const comp = Object.create(component.component.prototype, nodeProps) || new NodeComponent(nodeProps);
   nodeProps.node.stage0Context = comp;
   el.appendChild(comp.root);
   return comp;


### PR DESCRIPTION
Previous custom node creation did not create the extended NodeComponent object through specification of the `this.data.component` property as outlined in the documentation.